### PR TITLE
Make JSON API Serialization Do The Right Thing

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,15 @@
 class UsersController < ApplicationController
   def index
-    render json: User.all, include: :post, each_serializer: UsersSerializer
+    render json: User.all, include: includes
+  end
+
+  def show
+    render json: User.find(params[:id]), include: includes
+  end
+
+  private
+
+  def includes
+    params[:include]
   end
 end

--- a/app/serializers/profile_serializer.rb
+++ b/app/serializers/profile_serializer.rb
@@ -1,0 +1,5 @@
+class ProfileSerializer < ActiveModel::Serializer
+  type 'profiles'
+  attributes :name
+  belongs_to :user
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,5 @@
+class UserSerializer < ActiveModel::Serializer
+  type 'users'
+  attributes :name
+  has_one :profile
+end

--- a/app/serializers/users_serializer.rb
+++ b/app/serializers/users_serializer.rb
@@ -1,5 +1,0 @@
-class UsersSerializer < ActiveModel::Serializer
-  type 'users'
-  attributes :id, :name
-  has_one :profile { include_data true }
-end


### PR DESCRIPTION
The presence of a ProfileSerializer was the key here. With this change, I observe the following:

`curl localhost:3000/users.json?include=profile`

```
{
  "data": [
    {
      "id": "1",
      "type": "users",
      "attributes": {
        "name": "foo"
      },
      "relationships": {
        "profile": {
          "data": {
            "id": "1",
            "type": "profiles"
          }
        }
      }
    }
  ],
  "included": [
    {
      "id": "1",
      "type": "profiles",
      "attributes": {
        "name": "bar"
      },
      "relationships": {
        "user": {
          "meta": {
            
          }
        }
      }
    }
  ]
}
```